### PR TITLE
Updated to dmp 0.13.1 and fixed for Wildfly Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,17 +48,18 @@
                     <plugin>
                         <groupId>org.jolokia</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <version>0.11.5-M1</version>
+                        <version>0.13.1</version>
                         <configuration>
                             <images>
                                 <image>
                                     <alias>user</alias>
                                     <name>arungupta/javaee7-docker-maven</name>
                                     <build>
-                                        <from>arungupta/wildfly:8.2</from>
+                                        <from>jboss/wildfly:8.2.0.Final</from>
                                         <assembly>
                                             <descriptor>assembly.xml</descriptor>
-                                            <basedir>/</basedir>
+                                            <basedir>/opt/jboss/wildfly/standalone/deployments/</basedir>
+                                            <user>jboss:jboss:jboss</user>
                                         </assembly>
                                         <ports>
                                             <port>8080</port>
@@ -69,6 +70,11 @@
                                         <ports>
                                             <port>8080:8080</port>
                                         </ports>
+                                        <log>
+                                            <prefix>WF</prefix>
+                                            <date>none</date>
+                                            <color>cyan</color>
+                                        </log>
                                     </run>
                                 </image>
                             </images>

--- a/src/main/docker/assembly.xml
+++ b/src/main/docker/assembly.xml
@@ -7,7 +7,7 @@
             <includes>
                 <include>org.javaee7.sample:javaee7-docker-maven</include>
             </includes>
-            <outputDirectory>/opt/jboss/wildfly/standalone/deployments/</outputDirectory>
+            <outputDirectory>.</outputDirectory>
             <outputFileNameMapping>javaee7-docker-maven.war</outputFileNameMapping>
         </dependencySet>
     </dependencySets>


### PR DESCRIPTION
Also, added some log output to the consol. If you use '-Ddocker.follow' during startup you run Wildfly in the foreground, seeing all logs directly in the console. You can stop it with CTRL-C.
